### PR TITLE
LuxCharacter's wall slide animation cancels her jump animation when jumping in front of a wall

### DIFF
--- a/Source/ProjectLux/Private/Core/ProjectLuxCharacter.cpp
+++ b/Source/ProjectLux/Private/Core/ProjectLuxCharacter.cpp
@@ -395,7 +395,14 @@ void AProjectLuxCharacter::UpdateWallSlidingFlag()
 		{
 			if (IsTouchingWallForWallSlide())
 			{
-				SetWallSlidingFlag(true);
+				if (CharacterMovementComponent->Velocity.Z <= 0.0f)
+				{
+					SetWallSlidingFlag(true);
+				}
+				else
+				{
+					SetWallSlidingFlag(false);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
When the LuxCharacter is jumping in front of a wall, the jump animation is canceled by the wall slide animation, which leads to weird visuals. It gets even worse if she jumps in front of a small wall, where the jump animation is canceled by the wall slide animation and if you jump higher than the wall is high, the she is performing the “idle stand” animation midair.